### PR TITLE
Cow denylist refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(BZip2)
 find_package(Iconv)
-find_package(LibLZMA)
 
 pkg_check_modules(LUA REQUIRED IMPORTED_TARGET lua)
 pkg_check_modules(POPT REQUIRED IMPORTED_TARGET popt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(BZip2)
 find_package(Iconv)
+find_package(LibLZMA)
 
 pkg_check_modules(LUA REQUIRED IMPORTED_TARGET lua)
 pkg_check_modules(POPT REQUIRED IMPORTED_TARGET popt)

--- a/include/rpm/rpmte.h
+++ b/include/rpm/rpmte.h
@@ -266,6 +266,34 @@ rpmfiles rpmteFiles(rpmte te);
  */
 int rpmteVerified(rpmte te);
 
+/** \ingroup rpmte
+ * Set custom archive reader.
+ * @param te		transaction element
+ * @param plugin	plugin providing custom archive reader
+ */
+void rpmteSetCustomArchiveReader(rpmte te, rpmPlugin plugin);
+
+/** \ingroup rpmte
+ * Retrieve custom archive reader.
+ * @param te		transaction element
+ * @return          plugin providing custom archive reader
+ */
+rpmPlugin rpmteCustomArchiveReader(rpmte te);
+
+/** \ingroup rpmte
+ * Set custom file installer.
+ * @param te		transaction element
+ * @param plugin	plugin providing custom file installer
+ */
+void rpmteSetCustomFileInstaller(rpmte te, rpmPlugin plugin);
+
+/** \ingroup rpmte
+ * Retrieve custom file installer.
+ * @param te		transaction element
+ * @return          plugin providing custom file installer
+ */
+rpmPlugin rpmteCustomFileInstaller(rpmte te);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmplugins.h
+++ b/lib/rpmplugins.h
@@ -171,6 +171,7 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
 /** \ingroup rpmplugins
  * Call the fsm file install plugin hook
  * @param plugins	plugins structure
+ * @param te		processed transaction element
  * @param fi		file info iterator (or NULL)
  * @param path		file object path
  * @param file_mode	file object mode
@@ -178,13 +179,13 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
  * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallFsmFileInstall(rpmPlugins plugins, rpmfi fi,
+rpmRC rpmpluginsCallFsmFileInstall(rpmPlugins plugins, rpmte te, rpmfi fi,
 				   const char* path, mode_t file_mode,
 				   rpmFsmOp op);
 
 RPM_GNUC_INTERNAL
 rpmRC rpmpluginsCallFsmFileArchiveReader(rpmPlugins plugins, FD_t payload,
-					 rpmfiles files, rpmfi *fi);
+					 rpmfiles files, rpmte te, rpmfi *fi);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -81,6 +81,9 @@ struct rpmte_s {
     int failed;			/*!< (parent) install/erase failed */
 
     rpmfs fs;
+
+    rpmPlugin customArchiveReader;
+    rpmPlugin customFileInstaller;
 };
 
 /* forward declarations */
@@ -221,6 +224,9 @@ static int addTE(rpmte p, Header h, fnpyKey key, rpmRelocation * relocs)
 
     if (p->type == TR_ADDED)
 	p->pkgFileSize = headerGetNumber(h, RPMTAG_LONGSIGSIZE) + 96 + 256;
+
+    p->customArchiveReader = NULL;
+    p->customFileInstaller = NULL;
 
     rc = 0;
 
@@ -843,4 +849,24 @@ int rpmteProcess(rpmte te, pkgGoal goal, int num)
     }
 
     return failed;
+}
+
+void rpmteSetCustomArchiveReader(rpmte te, rpmPlugin plugin) {
+    if (!te) return;
+    te->customArchiveReader = plugin;
+}
+
+rpmPlugin rpmteCustomArchiveReader(rpmte te) {
+    if (!te) return NULL;
+    return te->customArchiveReader;
+}
+
+void rpmteSetCustomFileInstaller(rpmte te, rpmPlugin plugin) {
+    if (!te) return;
+    te->customFileInstaller = plugin;
+}
+
+rpmPlugin rpmteCustomFileInstaller(rpmte te) {
+    if (!te) return NULL;
+    return te->customFileInstaller;
 }

--- a/plugins/reflink.c
+++ b/plugins/reflink.c
@@ -162,6 +162,8 @@ static rpmRC reflink_psm_pre(rpmPlugin plugin, rpmte te) {
     }
     rpmlog(RPMLOG_DEBUG, _("reflink: *is* transcoded\n"));
     state->transcoded = 1;
+    rpmteSetCustomArchiveReader(te, plugin);
+    rpmteSetCustomFileInstaller(te, plugin);
 
     state->files = rpmteFiles(te);
     /* tail of file contains offset_table, offset_checksums then magic */
@@ -385,9 +387,9 @@ static rpmRC reflink_fsm_file_archive_reader(rpmPlugin plugin, FD_t payload,
     reflink_state state = rpmPluginGetData(plugin);
     if(state->transcoded) {
 	*fi = rpmfilesIter(files, RPMFI_ITER_FWD);
-	return RPMRC_PLUGIN_CONTENTS;
+	return RPMRC_OK;
     }
-    return RPMRC_OK;
+    return RPMRC_FAIL;
 }
 
 struct rpmPluginHooks_s reflink_hooks = {


### PR DESCRIPTION
# Description
This is a refactoring of PR [#1470](https://github.com/rpm-software-management/rpm/pull/1470).
The RPM CoW plugin is refactored to register as owner of payloads transcoded by `rpm2extents` as suggested in comment [#2057](https://github.com/rpm-software-management/rpm/discussions/2057#discussioncomment-2897701).
# How it works
I defined 2 new fields of type `rpmPlugin` (with associated getters and setters) in `rpmte` structure:
- [`customArchiveReader`](https://github.com/rphibel/rpm/blob/8de078508954e005ba0c974389979070cfe9431d/lib/rpmte.c#L85)
- [`customFileInstaller`](https://github.com/rphibel/rpm/blob/8de078508954e005ba0c974389979070cfe9431d/lib/rpmte.c#L86)

When a plugin wants to register as an archive reader for a package, it sets the field `customArchiveReader` in the [`psm_pre` ](https://github.com/rphibel/rpm/blob/8de078508954e005ba0c974389979070cfe9431d/plugins/reflink.c#L165)stage.
Similarly, if it wants to register as a file installer it sets the `customFileInstaller` field.

Then in [`fsm.c`](https://github.com/rphibel/rpm/blob/8de078508954e005ba0c974389979070cfe9431d/lib/fsm.c#L849), if these fields are set, archive reading, file installation is deferred to the plugin.
